### PR TITLE
Remove BASEURL from originalRequest.url check in errors

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -1,6 +1,5 @@
 import axiosInstance from "./axios";
 import jwtDecode from "jwt-decode";
-import { useAuth } from "./hooks/useAuth";
 
 const apiSettings = {
   register: async (data) => {
@@ -68,7 +67,7 @@ const apiSettings = {
       let categories = await axiosInstance.get(`categories/`);
       return categories.data;
     } catch (ex) {
-      return ex;
+      return [];
     }
   },
   getActiveAuctions: async (page, searchTerm, category) => {
@@ -114,7 +113,6 @@ const apiSettings = {
   getWatchList: async (userId) => {
     try {
       let watchList = await axiosInstance.get(`users/${userId}/watchlist`);
-      let array = Object.values(watchList.data);
       return Object.values(watchList.data);
     } catch (ex) {
       return ex;

--- a/src/axios.js
+++ b/src/axios.js
@@ -22,8 +22,9 @@ axiosInstance.interceptors.response.use(
     return response;
   },
   async function (error) {
-    const originalRequest = error.config;
-
+    let originalRequest = error.config;
+    console.log(error.response);
+    console.log(originalRequest.url);
     if (typeof error.response === "undefined") {
       alert(
         "A server/network error occurred. " +
@@ -35,7 +36,7 @@ axiosInstance.interceptors.response.use(
 
     if (
       error.response.status === 401 &&
-      originalRequest.url === baseURL + "users/token/refresh/"
+      originalRequest.url === "/users/token/refresh/"
     ) {
       window.location.href = "/login/";
       return Promise.reject(error);
@@ -55,10 +56,11 @@ axiosInstance.interceptors.response.use(
         const now = Math.ceil(Date.now() / 1000);
 
         if (tokenParts.exp > now) {
-          return axiosInstance
+          console.log("attempting refresh of access token");
+          return await axiosInstance
             .post("/users/token/refresh/", { refresh: refreshToken })
             .then((response) => {
-              console.log(response);
+              console(response);
               localStorage.setItem("access_token", response.data.access);
               localStorage.setItem("refresh_token", response.data.refresh);
 
@@ -66,27 +68,33 @@ axiosInstance.interceptors.response.use(
 
               axiosInstance.defaults.headers["Authorization"] =
                 newAuthorizationHeader;
-              originalRequest.defaults.headers["Authorization"] =
-                newAuthorizationHeader;
-              console.log(originalRequest);
+              originalRequest.headers["Authorization"] = newAuthorizationHeader;
 
               return axiosInstance(originalRequest);
             })
             .catch((err) => {
+              // Abort if refresh token is invalid
               console.log(err);
+              removeTokensAndLogOut();
             });
         } else {
           console.log("Refresh token is expired", tokenParts.exp, now);
-          window.location.href = "/login/";
+          removeTokensAndLogOut();
         }
       } else {
         console.log("Refresh token not available.");
-        window.location.href = "/login/";
+        removeTokensAndLogOut();
       }
     }
 
     return Promise.reject(error);
   }
 );
+
+const removeTokensAndLogOut = () => {
+  localStorage.removeItem("access_token");
+  localStorage.removeItem("refresh_token");
+  window.location.href = "/login/";
+};
 
 export default axiosInstance;

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -62,7 +62,6 @@ export function useProvideAuth() {
     const checkUser = async () => {
       try {
         let token = await localStorage.getItem("access_token");
-        console.log("useAuth useEffect checkUser", token);
         setUser(jwtDecode(token));
       } catch (ex) {
         setUser(null);


### PR DESCRIPTION
A check against the API call was attempting to add the BaseURL to the API url endpoint, however the data was not returned this way from Axios, which prevented the error from being properly caught and handled.